### PR TITLE
Allow recovering from failing to add network profile by rebooting with same config

### DIFF
--- a/src/buggd/apps/buggd/utils.py
+++ b/src/buggd/apps/buggd/utils.py
@@ -206,7 +206,6 @@ def copy_sd_card_config(sd_mount_loc, config_fname):
     # Check it's not just the same as the one we're already using
     if os.path.exists(local_config_path) and filecmp.cmp(sd_config_path, local_config_path):
         logger.info('SD card config file ({}) matches existing config ({})'.format(sd_config_path, local_config_path))
-        return
     else:
         # Copy the SD config file and reboot
         # TODO: Indicate with LEDs / buzzer a new config has been found

--- a/src/buggd/apps/buggd/utils.py
+++ b/src/buggd/apps/buggd/utils.py
@@ -207,11 +207,11 @@ def copy_sd_card_config(sd_mount_loc, config_fname):
     if os.path.exists(local_config_path) and filecmp.cmp(sd_config_path, local_config_path):
         logger.info('SD card config file ({}) matches existing config ({})'.format(sd_config_path, local_config_path))
         return
-
-    # Copy the SD config file and reboot
-    # TODO: Indicate with LEDs / buzzer a new config has been found
-    logger.info('Copied config from SD to local')
-    shutil.copyfile(sd_config_path, local_config_path)
+    else:
+        # Copy the SD config file and reboot
+        # TODO: Indicate with LEDs / buzzer a new config has been found
+        logger.info('Copied config from SD to local')
+        shutil.copyfile(sd_config_path, local_config_path)
 
     # Try to configure modem, but it's not required so escape any errors
     try:


### PR DESCRIPTION
Before, if the network profile fails to be added, rebooting will not cause it to try again because it exits early if it detects the same config.
Now, it will always try again.